### PR TITLE
convert_timeseries_input works on functions

### DIFF
--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -30,3 +30,11 @@ class TestTimeseriesTransformer:
         estimator = DummyTransformer(n_components=2)
         data = estimator.fit_transform(np.random.random((10, 15, 10)))
         assert data.shape == (10, 2)
+
+    def test_convert_timeseries_input_works_on_functions(self):
+        def load(data):
+            return data
+
+        func = convert_timeseries_input(load)
+        returned_data = func(np.random.random((10, 4, 2)))
+        assert returned_data.shape == (10, 8)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -38,3 +38,30 @@ class TestTimeseriesTransformer:
         func = convert_timeseries_input(load)
         returned_data = func(np.random.random((10, 4, 2)))
         assert returned_data.shape == (10, 8)
+
+    def test_convert_output_to_timeseries_returns_timeseries(self):
+        @convert_output_to_timeseries
+        def load():
+            return np.random.random((10, 5, 2))
+
+        # This should return a timeseries dataset as normal
+        returned_data = load()
+        assert returned_data.shape == (10, 5, 2)
+
+    def test_convert_output_to_timeseries_converts_two_dimensional_output(self):
+        @convert_output_to_timeseries
+        def load():
+            return np.random.random((10, 5))
+
+        returned_data = load()
+        assert returned_data.shape == (10, 5, 1)
+
+    def test_convert_output_to_timeseries_raises_if_output_is_more_than_three_dimensional(
+        self
+    ):
+        @convert_output_to_timeseries
+        def load():
+            return np.random.random((5, 4, 3, 2))
+
+        with pytest.raises(AssertionError):
+            load()

--- a/timekeep/conversion.py
+++ b/timekeep/conversion.py
@@ -8,12 +8,15 @@ from tslearn.utils import to_sklearn_dataset, to_time_series_dataset
 
 def convert_timeseries_input(func):
     def inner(*args, **kwargs):
-        assert len(args) >= 2
-        x = args[1]  # self, then X
-        assert isinstance(x, np.ndarray)
+        dim = 0
+        x = args[dim]  # For functions, x should be first argument
+        if not isinstance(x, np.ndarray):
+            dim = 1
+            x = args[dim]  # For methods, arguments are (self, x, ...)
+            assert isinstance(x, np.ndarray)
 
         x = to_sklearn_dataset(x)
-        args = [args[i] if i != 1 else x for i in range(len(args))]
+        args = [args[i] if i != dim else x for i in range(len(args))]
 
         return func(*args, **kwargs)
 
@@ -24,7 +27,6 @@ def convert_output_to_timeseries(func):
     def inner(*args, **kwargs):
         data = func(*args, **kwargs)
         assert len(data.shape) == 2
-
         return to_time_series_dataset(data)
 
     return inner

--- a/timekeep/conversion.py
+++ b/timekeep/conversion.py
@@ -26,6 +26,10 @@ def convert_timeseries_input(func):
 def convert_output_to_timeseries(func):
     def inner(*args, **kwargs):
         data = func(*args, **kwargs)
+        if len(data.shape) == 3:
+            return data
+
+        # If it's not 2-dimensional, we can't handle it
         assert len(data.shape) == 2
         return to_time_series_dataset(data)
 


### PR DESCRIPTION
**This PR:**
Relaxes the requirement in convert_timeseries_input for there to be at least two arguments. Initially the first argument assumed to be a numpy array, as should be the case for functions. If not, convert_timeseries_input works as before

**To test:**
```
import numpy as np
import timekeep.conversion as tkc

@tkc.convert_timeseries_input
def load(data):
    return data

data = load(np.random.random((5, 4, 2))
```
Data should be shape (5, 8)