### PR TITLE
Test multiple python versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.8"
 
 install:
-  - pip install test-requirements.txt
+  - pip install -r test-requirements.txt
   - python setup.py install
 script:
   - black --check timekeep

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 dist: bionic
 language: python
 python:
+  - "3.6"
   - "3.7"
+  - "3.8"
 
-# Taken from https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
 install:
-  - sudo apt-get update
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - source "$HOME/miniconda/etc/profile.d/conda.sh"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION Cython
-  - conda activate test-environment
-  - conda install --yes --file test-requirements.txt
+  - pip install test-requirements.txt
   - python setup.py install
 script:
   - black --check timekeep


### PR DESCRIPTION
**This PR**:
* Stops using conda in travis
* Tests in python 3.6, 3.7, 3.8

Fixes #3 