### PR TITLE
Add cyclical conversion tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(
     packages=["timekeep"],
     install_requires=["numpy", "sklearn", "pandas"],
     include_package_data=True,
-    python_requires=">=3.6"
+    python_requires=">=3.6",
 )

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -61,7 +61,7 @@ class TestTimeseriesTransformer:
         assert returned_data.shape == (10, 5, 1)
 
     def test_convert_output_to_timeseries_raises_if_output_is_more_than_three_dimensional(
-        self
+        self,
     ):
         @convert_output_to_timeseries
         def load():
@@ -129,6 +129,18 @@ class TestTimeseriesTransformer:
         with pytest.raises(ValueError):
             data = to_flat_dataset(np.random.random((10,)))
 
+    def test_flat_to_stacked_to_flat_returns_same_dataframe(self):
+        data = pd.DataFrame(
+            {
+                "id": [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                "time": [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2],
+                "kind": [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1],
+                "value": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            }
+        )
+        converted_data = to_stacked_dataset(to_flat_dataset(data))
+        assert_frame_equal(converted_data, data)
+
     def test_to_stacked_dataset_can_accept_stacked_dataset(self):
         data = pd.DataFrame(
             {
@@ -189,6 +201,31 @@ class TestTimeseriesTransformer:
         with pytest.raises(ValueError):
             data = to_stacked_dataset(np.random.random((10,)))
 
+    def test_stacked_to_flat_to_stacked_returns_same_dataframe(self):
+        data = pd.DataFrame(
+            {
+                "id": [0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1],
+                "time": [0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2],
+                "kind": [
+                    "value_1",
+                    "value_1",
+                    "value_1",
+                    "value_1",
+                    "value_1",
+                    "value_1",
+                    "value_2",
+                    "value_2",
+                    "value_2",
+                    "value_2",
+                    "value_2",
+                    "value_2",
+                ],
+                "value": [1, 2, 3, 4, 5, 6, 10, 9, 8, 7, 6, 5],
+            }
+        )
+        converted_data = to_stacked_dataset(to_flat_dataset(data))
+        assert_frame_equal(converted_data, data)
+
     def test_to_timeseries_dataset_converts_flat_dataset(self):
         data = pd.DataFrame(
             {
@@ -224,7 +261,7 @@ class TestTimeseriesTransformer:
         )
 
     def test_to_timeseries_dataset_converts_sklearn_dataset_with_all_dims_provided(
-        self
+        self,
     ):
         data = pd.DataFrame(np.arange(120).reshape((10, 12)))
         converted_data = to_timeseries_dataset(data, t=6, d=2)
@@ -247,7 +284,7 @@ class TestTimeseriesTransformer:
         assert_array_equal(converted_data, np.arange(120).reshape((10, 4, 3)))
 
     def test_to_timeseries_dataset_converts_sklearn_dataset_with_d_equal_to_one_when_no_dims_provided(
-        self
+        self,
     ):
         data = np.arange(120).reshape(10, 12)
         converted_data = to_timeseries_dataset(data)
@@ -258,10 +295,15 @@ class TestTimeseriesTransformer:
         )
 
     def test_to_timeseries_dataset_raises_value_error_if_data_format_not_recognised(
-        self
+        self,
     ):
         with pytest.raises(ValueError):
             data = to_timeseries_dataset(np.random.random((10,)))
+
+    def test_timeseries_to_sklearn_to_timeseries_return_same_array(self):
+        data = np.random.random((18, 26, 4))
+        converted_data = to_timeseries_dataset(to_sklearn_dataset(data))
+        assert_array_equal(converted_data, data)
 
     def test_to_sklearn_dataset_converts_timeseries_dataset(self):
         datum = np.expand_dims(np.array([[1, 4], [2, 5], [3, 6]]), axis=0)
@@ -313,4 +355,23 @@ class TestTimeseriesTransformer:
         data = pd.DataFrame(np.random.random((12, 80)))
         converted_data = to_sklearn_dataset(data)
 
+        assert_array_equal(converted_data, data)
+
+    def test_sklearn_to_timeseries_to_sklearn_returns_same_array(self):
+        data = np.random.random((18, 104))
+        converted_data = to_sklearn_dataset(to_timeseries_dataset(data))
+        assert_array_equal(converted_data, data)
+
+    def test_sklearn_to_timeseries_to_sklearn_return_same_array_when_one_dimension_provided(
+        self,
+    ):
+        data = np.random.random((18, 104))
+        converted_data = to_sklearn_dataset(to_timeseries_dataset(data, t=26))
+        assert_array_equal(converted_data, data)
+
+    def test_sklearn_to_timeseries_to_sklearn_return_same_array_when_all_dimensions_provided(
+        self,
+    ):
+        data = np.random.random((18, 104))
+        converted_data = to_sklearn_dataset(to_timeseries_dataset(data, t=26, d=4))
         assert_array_equal(converted_data, data)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -266,35 +266,105 @@ class TestTimeseriesTransformer:
     def test_to_timeseries_dataset_converts_sklearn_dataset_with_all_dims_provided(
         self,
     ):
-        data = pd.DataFrame(np.arange(120).reshape((10, 12)))
+        data = pd.DataFrame(
+            np.array(
+                [
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+                ]
+            )
+        )
+
         converted_data = to_timeseries_dataset(data, t=6, d=2)
 
-        assert converted_data.shape == (10, 6, 2)
-        assert_array_equal(converted_data, np.arange(120).reshape((10, 6, 2)))
+        assert_array_equal(
+            converted_data,
+            np.array(
+                [
+                    [[0, 6], [1, 7], [2, 8], [3, 9], [4, 10], [5, 11]],
+                    [[12, 18], [13, 19], [14, 20], [15, 21], [16, 22], [17, 23]],
+                ]
+            ),
+        )
 
     def test_to_timeseries_dataset_converts_sklearn_dataset_with_t_provided(self):
-        data = pd.DataFrame(np.arange(120).reshape((10, 12)))
+        data = pd.DataFrame(
+            np.array(
+                [
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+                ]
+            )
+        )
         converted_data = to_timeseries_dataset(data, t=4)
 
-        assert converted_data.shape == (10, 4, 3)
-        assert_array_equal(converted_data, np.arange(120).reshape((10, 4, 3)))
+        assert_array_equal(
+            converted_data,
+            np.array(
+                [
+                    [[0, 4, 8], [1, 5, 9], [2, 6, 10], [3, 7, 11]],
+                    [[12, 16, 20], [13, 17, 21], [14, 18, 22], [15, 19, 23]],
+                ]
+            ),
+        )
 
     def test_to_timeseries_dataset_converts_sklearn_dataset_with_d_provided(self):
-        data = pd.DataFrame(np.arange(120).reshape(10, 12))
+        data = pd.DataFrame(
+            np.array(
+                [
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+                ]
+            )
+        )
+
         converted_data = to_timeseries_dataset(data, d=3)
 
-        assert converted_data.shape == (10, 4, 3)
-        assert_array_equal(converted_data, np.arange(120).reshape((10, 4, 3)))
+        assert_array_equal(
+            converted_data,
+            np.array(
+                [
+                    [[0, 4, 8], [1, 5, 9], [2, 6, 10], [3, 7, 11]],
+                    [[12, 16, 20], [13, 17, 21], [14, 18, 22], [15, 19, 23]],
+                ]
+            ),
+        )
 
     def test_to_timeseries_dataset_converts_sklearn_dataset_with_d_equal_to_one_when_no_dims_provided(
         self,
     ):
-        data = np.arange(120).reshape(10, 12)
+        data = pd.DataFrame(
+            np.array(
+                [
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                    [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+                ]
+            )
+        )
+
         converted_data = to_timeseries_dataset(data)
 
-        assert converted_data.shape == (10, 12, 1)
         assert_array_equal(
-            converted_data, np.expand_dims(np.arange(120).reshape((10, 12)), axis=2)
+            converted_data,
+            np.array(
+                [
+                    [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11]],
+                    [
+                        [12],
+                        [13],
+                        [14],
+                        [15],
+                        [16],
+                        [17],
+                        [18],
+                        [19],
+                        [20],
+                        [21],
+                        [22],
+                        [23],
+                    ],
+                ]
+            ),
         )
 
     def test_to_timeseries_dataset_raises_value_error_if_data_format_not_recognised(

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -139,7 +139,10 @@ class TestTimeseriesTransformer:
             }
         )
         converted_data = to_stacked_dataset(to_flat_dataset(data))
-        assert_frame_equal(converted_data, data)
+        assert_frame_equal(
+            converted_data.sort_values(["id", "kind", "time"]).reset_index(drop=True),
+            data,
+        )
 
     def test_to_stacked_dataset_can_accept_stacked_dataset(self):
         data = pd.DataFrame(
@@ -302,7 +305,7 @@ class TestTimeseriesTransformer:
 
     def test_timeseries_to_sklearn_to_timeseries_return_same_array(self):
         data = np.random.random((18, 26, 4))
-        converted_data = to_timeseries_dataset(to_sklearn_dataset(data))
+        converted_data = to_timeseries_dataset(to_sklearn_dataset(data), d=4)
         assert_array_equal(converted_data, data)
 
     def test_to_sklearn_dataset_converts_timeseries_dataset(self):

--- a/timekeep/conversion.py
+++ b/timekeep/conversion.py
@@ -322,7 +322,7 @@ def to_timeseries_dataset(
         elif d is None:
             d = int(total_size / (n * t))
 
-        return data.reshape((n, t, d))
+        return data.T.reshape((d, t, n)).T
 
 
 def to_sklearn_dataset(data) -> np.ndarray:


### PR DESCRIPTION
This PR adds unit tests for converting a timeseries dataset to another type and then back to the original type. The converted data and original data should be identical